### PR TITLE
Add directory feature extraction CLI

### DIFF
--- a/defender/requirements.txt
+++ b/defender/requirements.txt
@@ -6,3 +6,5 @@ annoy
 numpy
 tqdm
 pefile
+pandas
+lief


### PR DESCRIPTION
## Summary
- add process_directory utility to extract PE attributes into CSV/Parquet datasets
- expose command line interface for batch feature extraction
- declare pandas and lief dependencies

## Testing
- `python -m py_compile defender/feature_extractor.py`
- `python defender/feature_extractor.py --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77d6dbf3c83318999c65a409fabd7