### PR TITLE
Remove internal readme markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Downloaded files are written under the `data/` directory:
 ### Dataset sizes and storage
 
 The SOREL-20M collection is substantial – the full dataset is roughly
-8 TB in size, so syncing the `processed-data` subset still requires
-hundreds of gigabytes of free disk space【0184f6†L61-L63】. The
-compressed DikeDataset archive is about 326 MB and expands to roughly
-half a gigabyte on disk【a77a8c†L1-L2】. Ensure that the machine used for
+8 TB in size, so syncing the `processed-data` subset still requires
+hundreds of gigabytes of free disk space. The
+compressed DikeDataset archive is about 326 MB and expands to roughly
+half a gigabyte on disk. Ensure that the machine used for
 training has adequate storage available before downloading.
 
 Run the script from the repository root:


### PR DESCRIPTION
Remove internal reference markers from `README.md` because they are accidental documentation system artifacts unsuitable for user-facing content.

---
<a href="https://cursor.com/background-agent?bcId=bc-765845f7-68bb-487e-b9fd-4768d0f132b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-765845f7-68bb-487e-b9fd-4768d0f132b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

